### PR TITLE
Duplicate header 'DKIM-Signature' 対応 #7

### DIFF
--- a/forwarder/app.py
+++ b/forwarder/app.py
@@ -1,18 +1,22 @@
+from email import message_from_file
 import json
 import boto3
 import re
 import os
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 DISABLED_MESSAGE_IDS = ['AMAZON_SES_SETUP_NOTIFICATION']
 
 def lambda_handler(event, context):
 
-    print(json.dumps(event))
-    print(event.get('Records')[0].get('Sns').get('Message'))
+    logger.info(json.dumps(event))
+    logger.debug(event.get('Records')[0].get('Sns').get('Message'))
     message = json.loads(event.get('Records')[0].get('Sns').get('Message'))
     message_id = message.get('mail').get('messageId')
     if message_id in DISABLED_MESSAGE_IDS:
-        print('Skip Invalid messageID. (%s)' % message_id)
+        logger.info('Skip Invalid messageID. (%s)' % message_id)
         return
     notification_type = message.get('notificationType')
     destinations = message.get('mail').get('destination')
@@ -23,35 +27,33 @@ def lambda_handler(event, context):
     forward_to = os.environ['RCPT_TO'].split(",")
 
     # get s3 object
-    try:
-        s3 = boto3.client('s3')
-        response = s3.get_object(
-            Bucket = bucket_name,
-            Key    = object_key
-        )
-    except Exception as e:
-        raise e
+    s3 = boto3.client('s3')
+    response = s3.get_object(
+        Bucket = bucket_name,
+        Key    = object_key
+    )
 
     # change mail headers
-    try:
-        replaced_message = response['Body'].read().decode('utf-8')
-        replaced_message = re.sub("\nTo: .+?\n", "\nTo: %s\n" % ", ".join(forward_to), replaced_message, 1)
-        replaced_message = re.sub("\nFrom: .+?\n", "\nFrom: %s\n" % mail_from, replaced_message, 1)
-        replaced_message = re.sub("^Return-Path: .+?\n", "Return-Path: %s\n" % mail_from, replaced_message, 1)
-    except Exception as e:
-        raise e
+    raw_mail = response['Body']
+    msg = message_from_file(raw_mail)
+
+    del msg['DKIM-Signature']
+    del msg['To']
+    del msg['From']
+    del msg['Return-Path']
+
+    msg['To'] = ", ".join(forward_to)
+    msg['From'] = mail_from
+    msg['Return-Path'] = mail_from
 
     # send mail
-    try:
-        ses = boto3.client('ses')
-        response = ses.send_raw_email(
-            Source = mail_from,
-            Destinations = forward_to,
-            RawMessage={
-                'Data': replaced_message
-            }
-        )
-        print(json.dumps(response))
-        return response
-    except Exception as e:
-        raise e
+    ses = boto3.client('ses')
+    response = ses.send_raw_email(
+        Source = mail_from,
+        Destinations = forward_to,
+        RawMessage = {
+            'Data': msg.as_string()
+        }
+    )
+    logger.info(json.dumps(response))
+    return response


### PR DESCRIPTION
- 転送元メールヘッダーのDKIM-Signatureを削除